### PR TITLE
default-character-set: utf8mb4

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,3 +8,6 @@ mysql_config_file: /etc/mysql/my.cnf
 mysql_config_include_dir: /etc/mysql/conf.d
 mysql_socket: /var/run/mysqld/mysqld.sock
 mysql_supports_innodb_large_prefix: false
+mysql_default-character-set: utf8mb4
+mysql_character-set-client-handshake: "FALSE"
+mysql_collation-server: utf8mb4_unicode_ci


### PR DESCRIPTION
Intended to work with Debian. 
Assume will work with RedHat's MySQL also, so will add to RedHat defaults