### PR TITLE
default-character-set: utf8mb4

### DIFF
--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -14,3 +14,6 @@ mysql_config_file: /etc/my.cnf
 mysql_config_include_dir: /etc/my.cnf.d
 mysql_socket: /var/lib/mysql/mysql.sock
 mysql_supports_innodb_large_prefix: false
+mysql_default-character-set: utf8mb4
+mysql_character-set-client-handshake: "FALSE"
+mysql_collation-server: utf8mb4_unicode_ci


### PR DESCRIPTION
Applies to mariadb also?